### PR TITLE
chore: auto upload test report hosting with Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 # Stages:
 # - test: run `make test`
 # - code_quality: run `make code-quality`
+# - deploy: upload test report hosting with Github Pages
 #
 # ENV variables:
 # - CKB_DOCKER_IMAGE_TAG_NAME, set this ENV variable to specified test target version, get available tag from https://hub.docker.com/r/nervos/ckb/tags
@@ -25,17 +26,35 @@ language: java
 jdk:
   - oraclejdk9
 
+cache:
+  directories:
+    - $HOME/.m2 # for Maven
+    - libs/org/nervos/ckb/ckb-sdk-java/ # downloaded ckb-sdk-java jar files
+
 # install dependencies
 install: make setup
 
 env:
-  - CKB_START_LOCAL_TESTNET=1
+  - CKB_START_LOCAL_TESTNET=1 CKB_DOCKER_IMAGE_TAG_NAME=v0.13.0
 
 jobs:
   include:
     - stage: test
-      script: make test
+      script:
+        - make test
+        - scripts/travis-upload-test-report-to-gh-pages.sh
+
     # TODO: add code quality audit
     # - stage: code_quality
     #   if: branch != master # run code_audit for feature branches only
     #   script: make code-quality
+
+# following config is not working
+# Skipping a deployment with the pages provider because the current build is a pull request.
+# https://github.com/travis-ci/travis-ci/issues/7338
+# deploy:
+#   provider: pages
+#   skip_cleanup: true
+#   github_token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, as a secure variable
+#   keep_history: true
+#   local_dir: target/surefire-reports/

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ install-sdk:
 	fi;
 
 	@echo "Install SDK package"
-	mvn clean install -U -DskipTests
+	mvn clean install -DskipTests
 	@echo "You should see BUILD SUCCESS"
 
 # Download .jar from CI_URL$$CKB_SDK_JAVA_VERSION

--- a/scripts/travis-upload-test-report-to-gh-pages.sh
+++ b/scripts/travis-upload-test-report-to-gh-pages.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# This script is used to run on Travis CI to publish generated files to GitHub pages
+# 1. Create a orphan branch named gh-pages: https://help.github.com/en/articles/creating-project-pages-using-the-command-line#create-a-master-branch
+# 2. Enabling GitHub Pages to publish your site from gh-pages: https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages#enabling-github-pages-to-publish-your-site-from-master-or-gh-pages
+
+# NOTES: all UPPER-CASE variables are ENV variables, lower-case variables are local defined variables
+
+if [ $TRAVIS = "true" ]; then
+  echo "Starting to update gh-pages"
+
+  #gh page info
+  owner_name=`echo $TRAVIS_REPO_SLUG|cut -d / -f 1`
+  repo_name=`echo $TRAVIS_REPO_SLUG|cut -d / -f 2`
+  gh_pages_url="https://$owner_name.github.io/$repo_name"
+  travis_build_url="https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+  test_report_url="$gh_pages_url/reports/$TRAVIS_BUILD_ID/"
+  test_result_mark=`[ $TRAVIS_TEST_RESULT = 0 ] && printf "✔" || printf "✘"`
+
+  #copy data we're interested in to other place
+  mkdir $HOME/tmp
+  cp -R target/surefire-reports/html/ $HOME/tmp/$TRAVIS_BUILD_ID/
+
+  #go to home
+  cd $HOME
+
+  #using token clone gh-pages branch
+  git clone --quiet --branch=gh-pages https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git gh-pages > /dev/null
+
+  #go into diractory and copy data we're interested in to that directory
+  cd gh-pages
+  mkdir -p reports
+
+  # TODO: delete outdated reports
+
+  # add new report
+  mv $HOME/tmp/$TRAVIS_BUILD_ID/ reports/
+
+  # update index.html
+  echo "<div><a href=\"$test_report_url\">Test report</a> for <a href=\"$travis_build_url\">Build #$TRAVIS_BUILD_NUMBER</a> $test_result_mark</div>" >> index.html
+
+  #setup git user
+  git config user.email "travis@travis-ci.org"
+  git config user.name "Travis CI"
+
+  #add, commit and push files
+  commit_message="Test report $test_report_url for CI build $travis_build_url"
+  git add -f .
+  git commit -m "$commit_message"
+  git push -fq origin gh-pages > /dev/null
+
+  echo "Test report uploaded to $test_report_url"
+fi


### PR DESCRIPTION
auto upload test report after CI job, for example:

CI job: https://travis-ci.com/nervosnetwork/ckb-system-testing/jobs/208162021

![Screen Shot 2019-06-15 at 9 53 25 AM](https://user-images.githubusercontent.com/71397/59545629-73d66a00-8f53-11e9-81b1-5731c12cab71.png)

and the test report url is https://nervosnetwork.github.io/ckb-system-testing/reports/115605316/

also update the index page of GH Pages as https://nervosnetwork.github.io/ckb-system-testing/, for example:

![Screen Shot 2019-06-15 at 9 52 18 AM](https://user-images.githubusercontent.com/71397/59545641-a2ecdb80-8f53-11e9-824e-f9d7b144529e.png)

